### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -15,7 +15,7 @@
 
 ### Requirements
 
-* XCode 7
+* Xcode 7
 * Swift 2.0
 * iOS 8
 


### PR DESCRIPTION
This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
